### PR TITLE
 fix cfg case

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ pip3 install -e
 To enable, add the following to your jupyterhub file:
 
 ```
-C.JupyterHub.spawner_class = 'winlocalprocessspawner.WinLocalProcessSpawner'
+c.JupyterHub.spawner_class = 'winlocalprocessspawner.WinLocalProcessSpawner'
 ```
 


### PR DESCRIPTION
Running on windows, using a capital "C" fails while "c" which is consistent with the rest of the config file, works