### PR TITLE
correct spawner default command and default directory

### DIFF
--- a/winlocalprocessspawner/winlocalprocessspawner.py
+++ b/winlocalprocessspawner/winlocalprocessspawner.py
@@ -78,17 +78,14 @@ class WinLocalProcessSpawner(LocalProcessSpawner):
             else:
                 # If the user profile is loaded, adjust APPDATA so the jupyter runtime files are stored
                 # in a per-user location.
-                
-                #If the token is None, the USERPROFILE points at the default directory which is not writable.
-                #this changes the path over to public documents, so at least its a writable location.
-                if 'USERPROFILE' in user_env:
-                    if user_env['USERPROFILE'].lower() == 'c:\\users\\default':
-                        if 'PUBLIC' in user_env:
-                            user_env['USERPROFILE'] = user_env['PUBLIC'] 
-                
                 if 'APPDATA' in user_env:
                     env['APPDATA'] = user_env['APPDATA']
                     env['USERPROFILE'] = user_env['USERPROFILE']
+                else:
+                    #If the 'APPDATA' does not exist, the USERPROFILE points at the default 
+                    #directory which is not writable. this changes the path over to public 
+                    #documents, so at least its a writable location.
+                    user_env['USERPROFILE'] = user_env['PUBLIC']
 
             # On Posix, the cwd is set to ~ before spawning the singleuser server (preexec_fn).
             # Windows Popen doesn't have preexec_fn support, so we need to set cwd directly.

--- a/winlocalprocessspawner/winlocalprocessspawner.py
+++ b/winlocalprocessspawner/winlocalprocessspawner.py
@@ -36,58 +36,14 @@ class WinLocalProcessSpawner(LocalProcessSpawner):
                 env[key] = os.environ[key]
         return env
         
-        
-    def get_spawner_cmd(self):
-        """Using the config file, determine the absolute path of the script to run when spawning a new instance"""
-        #config: c.spawner.cmd
-        spawner_cmd=self.cmd
-        #this is just checking for empty settings, 
-        #which admittedly the parent probably fixes for you anyway
-        if spawner_cmd is None or spawner_cmd is '' or spawner_cmd is []:
-            spawner_cmd = 'jupyterhub-singleuser'
-            self.log.debug("no c.spawner.cmd specified, using default jupyterhub-singleuser")
-        
-        #jupyter docs say c.spawner.cmd is allowed to be a list or a string, 
-        #->convert it into a single path string
-        if type(spawner_cmd) is list:
-            #build path up
-            exe_cmd=''
-            for relpath in spawner_cmd:
-                exe_cmd=os.path.join(exe_cmd, relpath)
-        else:
-            exe_cmd=spawner_cmd
-        
-        #now we try to find the script because we need abs path to launch
-        if not os.path.exists(exe_cmd):
-            self.log.debug("cmd provided is not absolute or in the working directory, searching PATH")
-            for path_elem in os.environ['PATH'].split(os.pathsep):
-                #create an absolute path using the PATH var and see if it exists
-                checkpath=os.path.join(path_elem, exe_cmd)
-                if os.path.exists(checkpath):
-                    self.log.debug("cmd found on PATH at %s", path_elem)
-                    #this is the full abs path we've been looking for
-                    exe_cmd=checkpath
-                    break
-            else:
-                self.log.warning("cmd not found on path or in working directory, this will likely fail")
-        else:
-            exe_cmd=os.path.abspath(exe_cmd) #does nothing if already abs
-        
-        #we now have our abs path, add it to the launch cmd set
-        self.log.debug("Spawner will execute: %s", exe_cmd)
-        
-        return exe_cmd
-
     async def start(self):
         """Start the single-user server."""
         self.port = random_port()
         cmd = []
         env = self.get_env()
         token = None
-
-        cmd.append(sys.executable)
         
-        cmd.append(self.get_spawner_cmd())
+        cmd.extend(self.cmd)
 
         cmd.extend(self.get_args())
 

--- a/winlocalprocessspawner/winlocalprocessspawner.py
+++ b/winlocalprocessspawner/winlocalprocessspawner.py
@@ -35,14 +35,14 @@ class WinLocalProcessSpawner(LocalProcessSpawner):
             if key in os.environ:
                 env[key] = os.environ[key]
         return env
-        
+
     async def start(self):
         """Start the single-user server."""
         self.port = random_port()
         cmd = []
         env = self.get_env()
         token = None
-        
+
         cmd.extend(self.cmd)
 
         cmd.extend(self.get_args())

--- a/winlocalprocessspawner/winlocalprocessspawner.py
+++ b/winlocalprocessspawner/winlocalprocessspawner.py
@@ -44,7 +44,13 @@ class WinLocalProcessSpawner(LocalProcessSpawner):
         token = None
 
         cmd.append(sys.executable)
-        py_scripts_dir = os.path.join(os.path.dirname(sys.executable), 'Scripts')
+        #in virtualenv, exe is in Scripts folder already vs main environment where exe is a python root
+        if hasattr(sys, 'real_prefix'):
+            #in virtual env
+            py_scripts_dir = os.path.dirname(sys.executable)
+        else:
+            #in main env
+            py_scripts_dir = os.path.join(os.path.dirname(sys.executable), 'Scripts')
         cmd.append(os.path.join(py_scripts_dir, "jupyterhub-singleuser"))
 
         cmd.extend(self.get_args())

--- a/winlocalprocessspawner/winlocalprocessspawner.py
+++ b/winlocalprocessspawner/winlocalprocessspawner.py
@@ -78,6 +78,14 @@ class WinLocalProcessSpawner(LocalProcessSpawner):
             else:
                 # If the user profile is loaded, adjust APPDATA so the jupyter runtime files are stored
                 # in a per-user location.
+                
+                #If the token is None, the USERPROFILE points at the default directory which is not writable.
+                #this changes the path over to public documents, so at least its a writable location.
+                if 'USERPROFILE' in user_env:
+                    if user_env['USERPROFILE'].lower() == 'c:\\users\\default':
+                        if 'PUBLIC' in user_env:
+                            user_env['USERPROFILE'] = user_env['PUBLIC'] 
+                
                 if 'APPDATA' in user_env:
                     env['APPDATA'] = user_env['APPDATA']
                     env['USERPROFILE'] = user_env['USERPROFILE']


### PR DESCRIPTION
Per commit c6d2a54 ("WinLocalProcessSpawner: enable usage without WinAuthenticator") this change makes it so that the root directory used is public documents vs default documents (not writable). I tested this against https://github.com/jupyterhub/tmpauthenticator on windows 10.

The code as it was also did not work within a virtual environment due to how paths change, so I put in a check for that. 