### PR TITLE
get_env: keep TEMP variable, as it is used by the IRKernel

### DIFF
--- a/winlocalprocessspawner/winlocalprocessspawner.py
+++ b/winlocalprocessspawner/winlocalprocessspawner.py
@@ -28,7 +28,7 @@ class WinLocalProcessSpawner(LocalProcessSpawner):
 
     def get_env(self):
         """Get the complete set of environment variables to be set in the spawned process."""
-        win_env_keep = ['SYSTEMROOT', 'APPDATA', 'WINDIR', 'USERPROFILE']
+        win_env_keep = ['SYSTEMROOT', 'APPDATA', 'WINDIR', 'USERPROFILE', 'TEMP']
 
         env = super().get_env()
         for key in win_env_keep:


### PR DESCRIPTION
R uses the TEMP variable to create a sandbox. If the TEMP variable is
not defined, the IRKernel fails on startup with:

Fatal error: creation of tmpfile failed -- set TMPDIR suitably?

Signed-off-by: Alejandro Del Castillo <alejandro.delcastillo@ni.com>