### PR TITLE
Handle case where auth_state is provided but token is not present

### DIFF
--- a/winlocalprocessspawner/winlocalprocessspawner.py
+++ b/winlocalprocessspawner/winlocalprocessspawner.py
@@ -57,7 +57,9 @@ class WinLocalProcessSpawner(LocalProcessSpawner):
 
         auth_state = await self.user.get_auth_state()
         if auth_state:
-            token = pywintypes.HANDLE(auth_state['auth_token'])
+            token = auth_state.get('auth_token')
+            if token:
+                token = pywintypes.HANDLE(token)
 
         user_env = None
         cwd = None


### PR DESCRIPTION
In the event that this spawner is used with a custom authenticator which also modifies auth_state, we may end up in a situation where auth_state is present but does not contain the expected key. We should simply not set the token in this case, much like we already do if no auth_state is provided at all.