### PR TITLE
Fix spawned server exit code check and logging

### DIFF
--- a/winlocalprocessspawner/win_utils.py
+++ b/winlocalprocessspawner/win_utils.py
@@ -186,8 +186,15 @@ class PopenAsUser(Popen):
                             token %r ", err, executable, args, self._token)
             else:
                 win32event.WaitForSingleObject(hp, 1000)  # Wait at least one second before checking exit code
-                logger.error("ExitCode %r when calling CreateProcessAsUser executable %s args %s with the \
-                            token %r ", win32process.GetExitCodeProcess(hp), executable, args, self._token)
+                exit_code = win32process.GetExitCodeProcess(hp)
+                if exit_code != win32con.STILL_ACTIVE:
+                    logger.error(
+                        "ExitCode %r when calling CreateProcessAsUser executable %s args %s with the token %r ",
+                        win32process.GetExitCodeProcess(hp),
+                        executable,
+                        args,
+                        self._token
+                    )
         finally:
             # Child is launched. Close the parent's copy of those pipe
             # handles that only the child should have open.  You need


### PR DESCRIPTION
Previously, we were logging an error even if the spawn succeeded. The error mentioned error code 259, which simply indicates that the process is running as normal as per the remarks [here](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getexitcodeprocess). Now, we proceed as normal if the spawned instance is up and running.

Verified on my local server.