### PR TITLE
Fix do_execute_child call

### DIFF
--- a/winlocalprocessspawner/win_utils.py
+++ b/winlocalprocessspawner/win_utils.py
@@ -147,7 +147,7 @@ class PopenAsUser(Popen):
                         unused_restore_signals,
                         unused_gid, unused_gids, unused_uid, unused_umask,
                         unused_start_new_session):
-            self.do_execute_child(self, args, executable, preexec_fn, close_fds,
+            self.do_execute_child(args, executable, preexec_fn, close_fds,
                              pass_fds, cwd, env,
                              startupinfo, creationflags, shell,
                              p2cread, p2cwrite,
@@ -161,7 +161,7 @@ class PopenAsUser(Popen):
                        c2pread, c2pwrite,
                        errread, errwrite,
                        unused_restore_signals, unused_start_new_session):
-            self.do_execute_child(self, args, executable, preexec_fn, close_fds,
+            self.do_execute_child(args, executable, preexec_fn, close_fds,
                              pass_fds, cwd, env,
                              startupinfo, creationflags, shell,
                              p2cread, p2cwrite,


### PR DESCRIPTION
An error was introduced in the code after #16 , where I sent by mistake `self` as a parameter to the function call. Ran the code in JupyterHub and it works now.