### PR TITLE
Add `_apply_user_env_overrides` with tests, minor fix `PyHANDLE` deprecation warning, type annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+jupyterhub_cookie_secret
 *.cover
 *.py,cover
 .hypothesis/
@@ -104,6 +105,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.vscode
 env/
 venv/
 ENV/

--- a/tests/test_winlocalprocessspawner.py
+++ b/tests/test_winlocalprocessspawner.py
@@ -209,12 +209,12 @@ def test_start_preserves_get_env_vars_not_present_in_user_env(monkeypatch):
     assert env["JUPYTERHUB_API_TOKEN"] == "secret-token"
 
 
-def test_start_cwd_uses_userprofile_from_env_after_overrides(monkeypatch):
-    """start() derives cwd from env['USERPROFILE'] after _apply_user_env_overrides runs.
+def test_start_cwd_uses_userprofile_from_profile_env(monkeypatch):
+    """When token is present, cwd comes from env['USERPROFILE'] after the merge.
 
-    If a subclass overrides _apply_user_env_overrides to protect USERPROFILE
-    (e.g. a custom least-privilege path), that protected value must be used as
-    cwd — not the raw value from the Windows profile block.
+    A subclass that protects env['USERPROFILE'] (e.g. least-privilege custom path)
+    will have that protected value used as cwd, since cwd is read from env
+    (post-merge) when a token is present.
     """
 
     class ProtectiveSpawner(wps.WinLocalProcessSpawner):
@@ -245,14 +245,51 @@ def test_start_cwd_uses_userprofile_from_env_after_overrides(monkeypatch):
         "CreateEnvironmentBlock",
         lambda token, _inherit: {
             "APPDATA": "C:/Users/alice/AppData/Roaming",
-            "USERPROFILE": "C:/Users/alice",  # would overwrite the custom path
+            "USERPROFILE": "C:/Users/alice",
         },
     )
     monkeypatch.setattr(wps, "PopenAsUser", fake_popen)
 
     asyncio.run(spawner.start())
 
+    # token present → cwd from env after merge → subclass-protected value wins
     assert popen_calls[0][1]["cwd"] == "C:/JupyterHub/profiles/alice"
+
+
+def test_start_no_token_profile_env_still_merged_for_cwd(monkeypatch):
+    """cwd uses USERPROFILE from profile_env even when token is None.
+
+    env.update(profile_env) is skipped when there is no token, but cwd is
+    derived directly from profile_env['USERPROFILE'] so the user's home
+    directory is still used as the working directory.
+    """
+    spawner = make_spawner(auth_state=None)
+    spawner.get_env = lambda: {
+        "APPDATA": "C:/ServiceAccount/AppData",
+        "USERPROFILE": "C:/ServiceAccount",
+    }
+
+    popen_calls = []
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append((cmd, kwargs))
+        return subprocess.Popen([sys.executable, "-c", "raise SystemExit(0)"])
+
+    monkeypatch.setattr(wps, "random_port", lambda: 9996)
+    monkeypatch.setattr(
+        wps.win32profile,
+        "CreateEnvironmentBlock",
+        lambda token, _inherit: {
+            "APPDATA": "C:/Users/alice/AppData/Roaming",
+            "USERPROFILE": "C:/Users/alice",
+        },
+    )
+    monkeypatch.setattr(wps, "PopenAsUser", fake_popen)
+
+    asyncio.run(spawner.start())
+
+    # profile_env is merged even with no token, so cwd uses the profile USERPROFILE.
+    assert popen_calls[0][1]["cwd"] == "C:/Users/alice"
 
 
 def test_start_falls_back_to_tempdir_when_user_env_load_fails(monkeypatch):
@@ -337,14 +374,19 @@ class TestApplyUserEnvOverrides:
         assert env["USERPROFILE"] == "C:/Users/alice"
         assert env["EXISTING"] == "value"
 
-    def test_does_not_merge_profile_env_when_token_is_none(self):
-        """Windows profile vars should not be merged when token is None."""
+    def test_merges_profile_env_regardless_of_token(self):
+        """profile_env is merged into env only when token is present.
+
+        When token is None the merge is skipped, but cwd is still read
+        directly from profile_env so the user's USERPROFILE is used.
+        """
         spawner = self._make_spawner()
         env = {"EXISTING": "value"}
         profile_env = {"APPDATA": "C:/Users/alice/AppData"}
 
         spawner._apply_user_env_overrides(env, profile_env, token=None)
 
+        # merge skipped — APPDATA not copied into env
         assert "APPDATA" not in env
 
     def test_does_not_merge_profile_env_when_profile_env_is_none(self):

--- a/tests/test_winlocalprocessspawner.py
+++ b/tests/test_winlocalprocessspawner.py
@@ -170,6 +170,91 @@ def test_start_uses_userprofile_as_cwd_when_notebook_dir_unset(monkeypatch):
     assert created_token.detached == 1
 
 
+class TestApplyUserEnvOverrides:
+    """Unit tests for WinLocalProcessSpawner._apply_user_env_overrides."""
+
+    def _make_spawner(self):
+        spawner = wps.WinLocalProcessSpawner.__new__(wps.WinLocalProcessSpawner)
+        return spawner
+
+    def test_merges_user_env_when_token_and_user_env_present(self):
+        """User env vars should be merged into env when both token and user_env are given."""
+        spawner = self._make_spawner()
+        env = {"EXISTING": "value"}
+        user_env = {"APPDATA": "C:/Users/alice/AppData", "USERPROFILE": "C:/Users/alice"}
+        token = DummyToken(1)
+
+        spawner._apply_user_env_overrides(env, user_env, token)
+
+        assert env["APPDATA"] == "C:/Users/alice/AppData"
+        assert env["USERPROFILE"] == "C:/Users/alice"
+        assert env["EXISTING"] == "value"
+
+    def test_does_not_merge_user_env_when_token_is_none(self):
+        """User env vars should not be merged when token is None."""
+        spawner = self._make_spawner()
+        env = {"EXISTING": "value"}
+        user_env = {"APPDATA": "C:/Users/alice/AppData"}
+
+        spawner._apply_user_env_overrides(env, user_env, token=None)
+
+        assert "APPDATA" not in env
+
+    def test_does_not_merge_user_env_when_user_env_is_none(self):
+        """Nothing should be merged when user_env is None."""
+        spawner = self._make_spawner()
+        env = {"EXISTING": "value"}
+        token = DummyToken(1)
+
+        spawner._apply_user_env_overrides(env, user_env=None, token=token)
+
+        assert env == {"EXISTING": "value"}
+
+    def test_sets_userprofile_to_public_when_appdata_missing(self):
+        """USERPROFILE should be set to PUBLIC when APPDATA is absent from user_env."""
+        spawner = self._make_spawner()
+        env = {"PUBLIC": "C:/Users/Public"}
+        user_env = {"PUBLIC": "C:/Users/Public"}  # no APPDATA
+        token = DummyToken(1)
+
+        spawner._apply_user_env_overrides(env, user_env, token)
+
+        assert env["USERPROFILE"] == "C:/Users/Public"
+
+    def test_userprofile_falls_back_to_env_public_when_user_env_has_no_public(self):
+        """USERPROFILE fallback should use env PUBLIC if user_env has no PUBLIC key."""
+        spawner = self._make_spawner()
+        env = {"PUBLIC": "C:/Users/Public"}
+        user_env = {"HOMEPATH": "\\Users\\alice"}  # non-empty, no APPDATA, no PUBLIC
+        token = DummyToken(1)
+
+        spawner._apply_user_env_overrides(env, user_env, token)
+
+        assert env["USERPROFILE"] == "C:/Users/Public"
+
+    def test_userprofile_empty_string_when_no_public_anywhere(self):
+        """USERPROFILE should be empty string when PUBLIC is absent everywhere."""
+        spawner = self._make_spawner()
+        env = {}
+        user_env = {"HOMEPATH": "\\Users\\alice"}  # non-empty, no APPDATA, no PUBLIC
+        token = DummyToken(1)
+
+        spawner._apply_user_env_overrides(env, user_env, token)
+
+        assert env["USERPROFILE"] == ""
+
+    def test_does_not_override_userprofile_when_appdata_present(self):
+        """USERPROFILE should not be overridden when APPDATA is present in user_env."""
+        spawner = self._make_spawner()
+        env = {}
+        user_env = {"APPDATA": "C:/Users/alice/AppData", "USERPROFILE": "C:/Users/alice"}
+        token = DummyToken(1)
+
+        spawner._apply_user_env_overrides(env, user_env, token)
+
+        assert env["USERPROFILE"] == "C:/Users/alice"
+
+
 def test_start_falls_back_to_tempdir_when_user_env_load_fails(monkeypatch):
     """Start should use mkdtemp as cwd when user profile environment cannot be loaded."""
     spawner = make_spawner(auth_state=None)

--- a/tests/test_winlocalprocessspawner.py
+++ b/tests/test_winlocalprocessspawner.py
@@ -170,6 +170,45 @@ def test_start_uses_userprofile_as_cwd_when_notebook_dir_unset(monkeypatch):
     assert created_token.detached == 1
 
 
+def test_start_preserves_get_env_vars_not_present_in_user_env(monkeypatch):
+    """Vars set by get_env() that are absent from user_env must survive the merge.
+
+    Keys like JUPYTERHUB_API_TOKEN are set by JupyterHub's get_env() and will
+    never appear in a Windows user profile block, so they must not be silently
+    dropped when _apply_user_env_overrides merges user_env into env.
+    """
+    spawner = make_spawner(auth_state={"auth_token": 123})
+    spawner.get_env = lambda: {
+        "JUPYTERHUB_API_TOKEN": "secret-token",
+        "APPDATA": "C:/base/appdata",
+    }
+    handle_factory = DummyHandleFactory()
+
+    popen_calls = []
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append((cmd, kwargs))
+        return subprocess.Popen([sys.executable, "-c", "raise SystemExit(0)"])
+
+    monkeypatch.setattr(wps, "random_port", lambda: 9998)
+    monkeypatch.setattr(wps.pywintypes, "HANDLE", handle_factory)
+    monkeypatch.setattr(
+        wps.win32profile,
+        "CreateEnvironmentBlock",
+        lambda token, _inherit: {
+            "APPDATA": "C:/Users/alice/AppData/Roaming",
+            "USERPROFILE": "C:/Users/alice",
+            # JUPYTERHUB_API_TOKEN intentionally absent from the Windows profile block
+        },
+    )
+    monkeypatch.setattr(wps, "PopenAsUser", fake_popen)
+
+    asyncio.run(spawner.start())
+
+    env = popen_calls[0][1]["env"]
+    assert env["JUPYTERHUB_API_TOKEN"] == "secret-token"
+
+
 def test_start_falls_back_to_tempdir_when_user_env_load_fails(monkeypatch):
     """Start should use mkdtemp as cwd when user profile environment cannot be loaded."""
     spawner = make_spawner(auth_state=None)
@@ -239,58 +278,58 @@ class TestApplyUserEnvOverrides:
         spawner = wps.WinLocalProcessSpawner.__new__(wps.WinLocalProcessSpawner)
         return spawner
 
-    def test_merges_user_env_when_token_and_user_env_present(self):
-        """User env vars should be merged into env when both token and user_env are given."""
+    def test_merges_profile_env_when_token_and_profile_env_present(self):
+        """Windows profile vars should be merged into env when both token and profile_env are given."""
         spawner = self._make_spawner()
         env = {"EXISTING": "value"}
-        user_env = {"APPDATA": "C:/Users/alice/AppData", "USERPROFILE": "C:/Users/alice"}
+        profile_env = {"APPDATA": "C:/Users/alice/AppData", "USERPROFILE": "C:/Users/alice"}
         token = DummyToken(1)
 
-        spawner._apply_user_env_overrides(env, user_env, token)
+        spawner._apply_user_env_overrides(env, profile_env, token)
 
         assert env["APPDATA"] == "C:/Users/alice/AppData"
         assert env["USERPROFILE"] == "C:/Users/alice"
         assert env["EXISTING"] == "value"
 
-    def test_does_not_merge_user_env_when_token_is_none(self):
-        """User env vars should not be merged when token is None."""
+    def test_does_not_merge_profile_env_when_token_is_none(self):
+        """Windows profile vars should not be merged when token is None."""
         spawner = self._make_spawner()
         env = {"EXISTING": "value"}
-        user_env = {"APPDATA": "C:/Users/alice/AppData"}
+        profile_env = {"APPDATA": "C:/Users/alice/AppData"}
 
-        spawner._apply_user_env_overrides(env, user_env, token=None)
+        spawner._apply_user_env_overrides(env, profile_env, token=None)
 
         assert "APPDATA" not in env
 
-    def test_does_not_merge_user_env_when_user_env_is_none(self):
-        """Nothing should be merged when user_env is None."""
+    def test_does_not_merge_profile_env_when_profile_env_is_none(self):
+        """Nothing should be merged when profile_env is None."""
         spawner = self._make_spawner()
         env = {"EXISTING": "value"}
         token = DummyToken(1)
 
-        spawner._apply_user_env_overrides(env, user_env=None, token=token)
+        spawner._apply_user_env_overrides(env, profile_env=None, token=token)
 
         assert env == {"EXISTING": "value"}
 
     def test_sets_userprofile_to_public_when_appdata_missing(self):
-        """USERPROFILE should be set to PUBLIC when APPDATA is absent from user_env."""
+        """USERPROFILE should be set to PUBLIC when APPDATA is absent from profile_env."""
         spawner = self._make_spawner()
         env = {"PUBLIC": "C:/Users/Public"}
-        user_env = {"PUBLIC": "C:/Users/Public"}  # no APPDATA
+        profile_env = {"PUBLIC": "C:/Users/Public"}  # no APPDATA
         token = DummyToken(1)
 
-        spawner._apply_user_env_overrides(env, user_env, token)
+        spawner._apply_user_env_overrides(env, profile_env, token)
 
         assert env["USERPROFILE"] == "C:/Users/Public"
 
-    def test_userprofile_falls_back_to_env_public_when_user_env_has_no_public(self):
-        """USERPROFILE fallback should use env PUBLIC if user_env has no PUBLIC key."""
+    def test_userprofile_falls_back_to_env_public_when_profile_env_has_no_public(self):
+        """USERPROFILE fallback should use env PUBLIC if profile_env has no PUBLIC key."""
         spawner = self._make_spawner()
         env = {"PUBLIC": "C:/Users/Public"}
-        user_env = {"HOMEPATH": "\\Users\\alice"}  # non-empty, no APPDATA, no PUBLIC
+        profile_env = {"HOMEPATH": "\\Users\\alice"}  # non-empty, no APPDATA, no PUBLIC
         token = DummyToken(1)
 
-        spawner._apply_user_env_overrides(env, user_env, token)
+        spawner._apply_user_env_overrides(env, profile_env, token)
 
         assert env["USERPROFILE"] == "C:/Users/Public"
 
@@ -298,20 +337,101 @@ class TestApplyUserEnvOverrides:
         """USERPROFILE should be empty string when PUBLIC is absent everywhere."""
         spawner = self._make_spawner()
         env = {}
-        user_env = {"HOMEPATH": "\\Users\\alice"}  # non-empty, no APPDATA, no PUBLIC
+        profile_env = {"HOMEPATH": "\\Users\\alice"}  # non-empty, no APPDATA, no PUBLIC
         token = DummyToken(1)
 
-        spawner._apply_user_env_overrides(env, user_env, token)
+        spawner._apply_user_env_overrides(env, profile_env, token)
 
         assert env["USERPROFILE"] == ""
 
     def test_does_not_override_userprofile_when_appdata_present(self):
-        """USERPROFILE should not be overridden when APPDATA is present in user_env."""
+        """USERPROFILE should not be overridden when APPDATA is present in profile_env."""
         spawner = self._make_spawner()
         env = {}
-        user_env = {"APPDATA": "C:/Users/alice/AppData", "USERPROFILE": "C:/Users/alice"}
+        profile_env = {"APPDATA": "C:/Users/alice/AppData", "USERPROFILE": "C:/Users/alice"}
         token = DummyToken(1)
 
-        spawner._apply_user_env_overrides(env, user_env, token)
+        spawner._apply_user_env_overrides(env, profile_env, token)
 
         assert env["USERPROFILE"] == "C:/Users/alice"
+
+    def test_base_class_overwrites_env_key_present_in_profile_env(self):
+        """Base implementation merges profile_env on top of env, so conflicting keys are overwritten.
+
+        This documents the default behaviour that motivates subclasses to override
+        _apply_user_env_overrides when they need to protect specific keys.
+        """
+        spawner = self._make_spawner()
+        env = {"JUPYTERHUB_API_TOKEN": "secret-token"}
+        profile_env = {"JUPYTERHUB_API_TOKEN": "value-from-windows-profile"}
+        token = DummyToken(1)
+
+        spawner._apply_user_env_overrides(env, profile_env, token)
+
+        assert env["JUPYTERHUB_API_TOKEN"] == "value-from-windows-profile"
+
+    def test_subclass_can_protect_keys_from_profile_env_overwrite(self):
+        """A subclass override of _apply_user_env_overrides can protect specific keys.
+
+        Because _apply_user_env_overrides is a hook, subclasses can restore
+        critical values (e.g. JUPYTERHUB_* vars) after the merge so the Windows
+        profile block cannot replace them.
+        """
+
+        class ProtectiveSpawner(wps.WinLocalProcessSpawner):
+            def _apply_user_env_overrides(self, env, profile_env, token):
+                protected = {k: v for k, v in env.items() if k.startswith("JUPYTERHUB_")}
+                super()._apply_user_env_overrides(env, profile_env, token)
+                env.update(protected)
+
+        spawner = ProtectiveSpawner.__new__(ProtectiveSpawner)
+        env = {"JUPYTERHUB_API_TOKEN": "secret-token"}
+        profile_env = {"JUPYTERHUB_API_TOKEN": "value-from-windows-profile"}
+        token = DummyToken(1)
+
+        spawner._apply_user_env_overrides(env, profile_env, token)
+
+        assert env["JUPYTERHUB_API_TOKEN"] == "secret-token"
+
+    def test_base_class_overwrites_appdata_set_by_least_privilege_subclass(self):
+        """Base implementation overwrites APPDATA set before the merge.
+
+        In least-privilege mode a subclass sets a custom APPDATA path before
+        start() calls CreateEnvironmentBlock. The base env.update(profile_env)
+        then silently replaces it with the standard Roaming path from the
+        Windows profile block — demonstrating why the override hook is needed.
+        """
+        _PROFILE_DIR = "C:/JupyterHub/profiles/alice"
+        spawner = self._make_spawner()
+        env = {"APPDATA": f"{_PROFILE_DIR}/AppData/Roaming"}
+        profile_env = {"APPDATA": "C:/Users/alice/AppData/Roaming"}  # from CreateEnvironmentBlock
+        token = DummyToken(1)
+
+        spawner._apply_user_env_overrides(env, profile_env, token)
+
+        # base class overwrites — the custom path is lost
+        assert env["APPDATA"] == "C:/Users/alice/AppData/Roaming"
+
+    def test_subclass_can_protect_appdata_from_profile_env_overwrite(self):
+        """A subclass override can preserve a custom APPDATA set in least-privilege mode.
+
+        The override captures the caller-set APPDATA before the merge and
+        restores it afterwards, preventing CreateEnvironmentBlock from clobbering it.
+        """
+        _PROFILE_DIR = "C:/JupyterHub/profiles/alice"
+
+        class LeastPrivilegeSpawner(wps.WinLocalProcessSpawner):
+            def _apply_user_env_overrides(self, env, profile_env, token):
+                appdata = env.get("APPDATA")
+                super()._apply_user_env_overrides(env, profile_env, token)
+                if appdata:
+                    env["APPDATA"] = appdata
+
+        spawner = LeastPrivilegeSpawner.__new__(LeastPrivilegeSpawner)
+        env = {"APPDATA": f"{_PROFILE_DIR}/AppData/Roaming"}
+        profile_env = {"APPDATA": "C:/Users/alice/AppData/Roaming"}
+        token = DummyToken(1)
+
+        spawner._apply_user_env_overrides(env, profile_env, token)
+
+        assert env["APPDATA"] == f"{_PROFILE_DIR}/AppData/Roaming"

--- a/tests/test_winlocalprocessspawner.py
+++ b/tests/test_winlocalprocessspawner.py
@@ -209,6 +209,52 @@ def test_start_preserves_get_env_vars_not_present_in_user_env(monkeypatch):
     assert env["JUPYTERHUB_API_TOKEN"] == "secret-token"
 
 
+def test_start_cwd_uses_userprofile_from_env_after_overrides(monkeypatch):
+    """start() derives cwd from env['USERPROFILE'] after _apply_user_env_overrides runs.
+
+    If a subclass overrides _apply_user_env_overrides to protect USERPROFILE
+    (e.g. a custom least-privilege path), that protected value must be used as
+    cwd — not the raw value from the Windows profile block.
+    """
+
+    class ProtectiveSpawner(wps.WinLocalProcessSpawner):
+        def _apply_user_env_overrides(self, env, profile_env, token):
+            userprofile = env.get("USERPROFILE")
+            super()._apply_user_env_overrides(env, profile_env, token)
+            if userprofile:
+                env["USERPROFILE"] = userprofile
+
+    spawner = make_spawner(auth_state={"auth_token": 123})
+    spawner.__class__ = ProtectiveSpawner
+    spawner.get_env = lambda: {
+        "APPDATA": "C:/base/appdata",
+        "USERPROFILE": "C:/JupyterHub/profiles/alice",
+    }
+    handle_factory = DummyHandleFactory()
+
+    popen_calls = []
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append((cmd, kwargs))
+        return subprocess.Popen([sys.executable, "-c", "raise SystemExit(0)"])
+
+    monkeypatch.setattr(wps, "random_port", lambda: 9997)
+    monkeypatch.setattr(wps.pywintypes, "HANDLE", handle_factory)
+    monkeypatch.setattr(
+        wps.win32profile,
+        "CreateEnvironmentBlock",
+        lambda token, _inherit: {
+            "APPDATA": "C:/Users/alice/AppData/Roaming",
+            "USERPROFILE": "C:/Users/alice",  # would overwrite the custom path
+        },
+    )
+    monkeypatch.setattr(wps, "PopenAsUser", fake_popen)
+
+    asyncio.run(spawner.start())
+
+    assert popen_calls[0][1]["cwd"] == "C:/JupyterHub/profiles/alice"
+
+
 def test_start_falls_back_to_tempdir_when_user_env_load_fails(monkeypatch):
     """Start should use mkdtemp as cwd when user profile environment cannot be loaded."""
     spawner = make_spawner(auth_state=None)

--- a/tests/test_winlocalprocessspawner.py
+++ b/tests/test_winlocalprocessspawner.py
@@ -362,7 +362,7 @@ class TestApplyUserEnvOverrides:
         return spawner
 
     def test_merges_profile_env_when_token_and_profile_env_present(self):
-        """Windows profile vars should be merged into env when both token and profile_env are given."""
+        """Windows profile vars are merged into env when both token and profile_env are given."""
         spawner = self._make_spawner()
         env = {"EXISTING": "value"}
         profile_env = {"APPDATA": "C:/Users/alice/AppData", "USERPROFILE": "C:/Users/alice"}
@@ -444,7 +444,9 @@ class TestApplyUserEnvOverrides:
         assert env["USERPROFILE"] == "C:/Users/alice"
 
     def test_base_class_overwrites_env_key_present_in_profile_env(self):
-        """Base implementation merges profile_env on top of env, so conflicting keys are overwritten.
+        """Base implementation merges profile_env on top of env, so conflicting keys are
+        overwritten.
+
 
         This documents the default behaviour that motivates subclasses to override
         _apply_user_env_overrides when they need to protect specific keys.
@@ -489,9 +491,9 @@ class TestApplyUserEnvOverrides:
         then silently replaces it with the standard Roaming path from the
         Windows profile block — demonstrating why the override hook is needed.
         """
-        _PROFILE_DIR = "C:/JupyterHub/profiles/alice"
+        profile_dir = "C:/JupyterHub/profiles/alice"
         spawner = self._make_spawner()
-        env = {"APPDATA": f"{_PROFILE_DIR}/AppData/Roaming"}
+        env = {"APPDATA": f"{profile_dir}/AppData/Roaming"}
         profile_env = {"APPDATA": "C:/Users/alice/AppData/Roaming"}  # from CreateEnvironmentBlock
         token = DummyToken(1)
 
@@ -506,7 +508,7 @@ class TestApplyUserEnvOverrides:
         The override captures the caller-set APPDATA before the merge and
         restores it afterwards, preventing CreateEnvironmentBlock from clobbering it.
         """
-        _PROFILE_DIR = "C:/JupyterHub/profiles/alice"
+        profile_dir = "C:/JupyterHub/profiles/alice"
 
         class LeastPrivilegeSpawner(wps.WinLocalProcessSpawner):
             def _apply_user_env_overrides(self, env, profile_env, token):
@@ -516,10 +518,10 @@ class TestApplyUserEnvOverrides:
                     env["APPDATA"] = appdata
 
         spawner = LeastPrivilegeSpawner.__new__(LeastPrivilegeSpawner)
-        env = {"APPDATA": f"{_PROFILE_DIR}/AppData/Roaming"}
+        env = {"APPDATA": f"{profile_dir}/AppData/Roaming"}
         profile_env = {"APPDATA": "C:/Users/alice/AppData/Roaming"}
         token = DummyToken(1)
 
         spawner._apply_user_env_overrides(env, profile_env, token)
 
-        assert env["APPDATA"] == f"{_PROFILE_DIR}/AppData/Roaming"
+        assert env["APPDATA"] == f"{profile_dir}/AppData/Roaming"

--- a/tests/test_winlocalprocessspawner.py
+++ b/tests/test_winlocalprocessspawner.py
@@ -170,6 +170,68 @@ def test_start_uses_userprofile_as_cwd_when_notebook_dir_unset(monkeypatch):
     assert created_token.detached == 1
 
 
+def test_start_falls_back_to_tempdir_when_user_env_load_fails(monkeypatch):
+    """Start should use mkdtemp as cwd when user profile environment cannot be loaded."""
+    spawner = make_spawner(auth_state=None)
+    spawner.get_env = lambda: {"APPDATA": "", "JUPYTERHUB_API_TOKEN": "token"}
+
+    popen_calls = []
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append((cmd, kwargs))
+        return subprocess.Popen([sys.executable, "-c", "raise SystemExit(0)"])
+
+    monkeypatch.setattr(wps, "random_port", lambda: 10001)
+    monkeypatch.setattr(
+        wps.win32profile,
+        "CreateEnvironmentBlock",
+        lambda token, _inherit: (_ for _ in ()).throw(RuntimeError("no profile")),
+    )
+    monkeypatch.setattr(wps, "mkdtemp", lambda: "C:/tmp/fallback-dir")
+    monkeypatch.setattr(wps, "PopenAsUser", fake_popen)
+
+    ip, port = asyncio.run(spawner.start())
+
+    assert (ip, port) == ("127.0.0.1", 10001)
+    assert popen_calls[0][1]["cwd"] == "C:/tmp/fallback-dir"
+
+    warning_logs = [entry for entry in spawner.log.messages if entry[0] == "warning"]
+    assert warning_logs
+    assert "Failed to load user environment" in warning_logs[0][1]
+
+
+def test_start_permission_error_logs_and_detaches_token(monkeypatch):
+    """Start should log permission errors and detach token before re-raising."""
+    spawner = make_spawner(auth_state={"auth_token": 456})
+    handle_factory = DummyHandleFactory()
+
+    monkeypatch.setattr(wps, "random_port", lambda: 7777)
+    monkeypatch.setattr(wps.pywintypes, "HANDLE", handle_factory)
+    monkeypatch.setattr(
+        wps.win32profile,
+        "CreateEnvironmentBlock",
+        lambda token, _inherit: {
+            "APPDATA": "C:/Users/alice/AppData/Roaming",
+            "USERPROFILE": "C:/Users/alice",
+            "PUBLIC": "C:/Users/Public",
+        },
+    )
+    monkeypatch.setattr(
+        wps, "PopenAsUser", lambda *args, **kwargs: (_ for _ in ()).throw(PermissionError())
+    )
+    monkeypatch.setattr(wps.shutil, "which", lambda script: f"C:/resolved/{script}")
+
+    with pytest.raises(PermissionError):
+        asyncio.run(spawner.start())
+
+    error_logs = [entry for entry in spawner.log.messages if entry[0] == "error"]
+    assert error_logs
+    assert "Permission denied trying to run" in error_logs[0][1]
+
+    created_token = handle_factory.created[0]
+    assert created_token.detached == 1
+
+
 class TestApplyUserEnvOverrides:
     """Unit tests for WinLocalProcessSpawner._apply_user_env_overrides."""
 
@@ -253,65 +315,3 @@ class TestApplyUserEnvOverrides:
         spawner._apply_user_env_overrides(env, user_env, token)
 
         assert env["USERPROFILE"] == "C:/Users/alice"
-
-
-def test_start_falls_back_to_tempdir_when_user_env_load_fails(monkeypatch):
-    """Start should use mkdtemp as cwd when user profile environment cannot be loaded."""
-    spawner = make_spawner(auth_state=None)
-    spawner.get_env = lambda: {"APPDATA": "", "JUPYTERHUB_API_TOKEN": "token"}
-
-    popen_calls = []
-
-    def fake_popen(cmd, **kwargs):
-        popen_calls.append((cmd, kwargs))
-        return subprocess.Popen([sys.executable, "-c", "raise SystemExit(0)"])
-
-    monkeypatch.setattr(wps, "random_port", lambda: 10001)
-    monkeypatch.setattr(
-        wps.win32profile,
-        "CreateEnvironmentBlock",
-        lambda token, _inherit: (_ for _ in ()).throw(RuntimeError("no profile")),
-    )
-    monkeypatch.setattr(wps, "mkdtemp", lambda: "C:/tmp/fallback-dir")
-    monkeypatch.setattr(wps, "PopenAsUser", fake_popen)
-
-    ip, port = asyncio.run(spawner.start())
-
-    assert (ip, port) == ("127.0.0.1", 10001)
-    assert popen_calls[0][1]["cwd"] == "C:/tmp/fallback-dir"
-
-    warning_logs = [entry for entry in spawner.log.messages if entry[0] == "warning"]
-    assert warning_logs
-    assert "Failed to load user environment" in warning_logs[0][1]
-
-
-def test_start_permission_error_logs_and_detaches_token(monkeypatch):
-    """Start should log permission errors and detach token before re-raising."""
-    spawner = make_spawner(auth_state={"auth_token": 456})
-    handle_factory = DummyHandleFactory()
-
-    monkeypatch.setattr(wps, "random_port", lambda: 7777)
-    monkeypatch.setattr(wps.pywintypes, "HANDLE", handle_factory)
-    monkeypatch.setattr(
-        wps.win32profile,
-        "CreateEnvironmentBlock",
-        lambda token, _inherit: {
-            "APPDATA": "C:/Users/alice/AppData/Roaming",
-            "USERPROFILE": "C:/Users/alice",
-            "PUBLIC": "C:/Users/Public",
-        },
-    )
-    monkeypatch.setattr(
-        wps, "PopenAsUser", lambda *args, **kwargs: (_ for _ in ()).throw(PermissionError())
-    )
-    monkeypatch.setattr(wps.shutil, "which", lambda script: f"C:/resolved/{script}")
-
-    with pytest.raises(PermissionError):
-        asyncio.run(spawner.start())
-
-    error_logs = [entry for entry in spawner.log.messages if entry[0] == "error"]
-    assert error_logs
-    assert "Permission denied trying to run" in error_logs[0][1]
-
-    created_token = handle_factory.created[0]
-    assert created_token.detached == 1

--- a/tests/test_winlocalprocessspawner.py
+++ b/tests/test_winlocalprocessspawner.py
@@ -257,7 +257,7 @@ def test_start_cwd_uses_userprofile_from_profile_env(monkeypatch):
 
 
 def test_start_no_token_profile_env_still_merged_for_cwd(monkeypatch):
-    """cwd uses USERPROFILE from profile_env even when token is None.
+    """CWD uses USERPROFILE from profile_env even when token is None.
 
     env.update(profile_env) is skipped when there is no token, but cwd is
     derived directly from profile_env['USERPROFILE'] so the user's home
@@ -444,9 +444,7 @@ class TestApplyUserEnvOverrides:
         assert env["USERPROFILE"] == "C:/Users/alice"
 
     def test_base_class_overwrites_env_key_present_in_profile_env(self):
-        """Base implementation merges profile_env on top of env, so conflicting keys are
-        overwritten.
-
+        """Base class merges profile_env on top of env, so conflicting keys are overwritten.
 
         This documents the default behaviour that motivates subclasses to override
         _apply_user_env_overrides when they need to protect specific keys.

--- a/winlocalprocessspawner/token_utils.py
+++ b/winlocalprocessspawner/token_utils.py
@@ -6,7 +6,7 @@ import win32api
 import win32security
 
 
-def create_service_token(username: str, password: str) -> "pywintypes.PyHANDLE":
+def create_service_token(username: str, password: str) -> pywintypes.HANDLEType:
     """Logs on a Windows Service user, given its password, and returns a handle to the token."""
     token_handle = win32security.LogonUser(
         username,
@@ -19,7 +19,7 @@ def create_service_token(username: str, password: str) -> "pywintypes.PyHANDLE":
     return token_handle
 
 
-def restrict_token(token_handle: "pywintypes.PyHANDLE") -> "pywintypes.PyHANDLE":
+def restrict_token(token_handle: pywintypes.HANDLEType) -> pywintypes.HANDLEType:
     """Removes token privileges (except SeChangeNotifyPrivilege) and sets medium integrity level.
 
     Returns a new token, with restricted privileges, and medium integrity level.

--- a/winlocalprocessspawner/token_utils.py
+++ b/winlocalprocessspawner/token_utils.py
@@ -6,7 +6,7 @@ import win32api
 import win32security
 
 
-def create_service_token(username: str, password: str) -> pywintypes.HANDLEType:
+def create_service_token(username: str, password: str) -> "pywintypes.PyHANDLE":
     """Logs on a Windows Service user, given its password, and returns a handle to the token."""
     token_handle = win32security.LogonUser(
         username,
@@ -19,7 +19,7 @@ def create_service_token(username: str, password: str) -> pywintypes.HANDLEType:
     return token_handle
 
 
-def restrict_token(token_handle: pywintypes.HANDLEType) -> int:
+def restrict_token(token_handle: "pywintypes.PyHANDLE") -> "pywintypes.PyHANDLE":
     """Removes token privileges (except SeChangeNotifyPrivilege) and sets medium integrity level.
 
     Returns a new token, with restricted privileges, and medium integrity level.

--- a/winlocalprocessspawner/win_utils.py
+++ b/winlocalprocessspawner/win_utils.py
@@ -14,18 +14,6 @@ import win32process
 logger = logging.getLogger("winlocalprocessspawner")
 
 
-DWORD = ctypes.c_uint
-HANDLE = DWORD
-BOOL = ctypes.wintypes.BOOL
-
-CLOSEHANDLE = ctypes.windll.kernel32.CloseHandle
-CLOSEHANDLE.argtypes = [HANDLE]
-CLOSEHANDLE.restype = BOOL
-
-GENERIC_ACCESS = (
-    win32con.GENERIC_READ | win32con.GENERIC_WRITE | win32con.GENERIC_EXECUTE | win32con.GENERIC_ALL
-)
-
 WINSTA_ALL = (
     win32con.WINSTA_ACCESSCLIPBOARD
     | win32con.WINSTA_ACCESSGLOBALATOMS

--- a/winlocalprocessspawner/win_utils.py
+++ b/winlocalprocessspawner/win_utils.py
@@ -14,40 +14,6 @@ import win32process
 logger = logging.getLogger("winlocalprocessspawner")
 
 
-WINSTA_ALL = (
-    win32con.WINSTA_ACCESSCLIPBOARD
-    | win32con.WINSTA_ACCESSGLOBALATOMS
-    | win32con.WINSTA_CREATEDESKTOP
-    | win32con.WINSTA_ENUMDESKTOPS
-    | win32con.WINSTA_ENUMERATE
-    | win32con.WINSTA_EXITWINDOWS
-    | win32con.WINSTA_READATTRIBUTES
-    | win32con.WINSTA_READSCREEN
-    | win32con.WINSTA_WRITEATTRIBUTES
-    | win32con.DELETE
-    | win32con.READ_CONTROL
-    | win32con.WRITE_DAC
-    | win32con.WRITE_OWNER
-)
-
-
-DESKTOP_ALL = (
-    win32con.DESKTOP_CREATEMENU
-    | win32con.DESKTOP_CREATEWINDOW
-    | win32con.DESKTOP_ENUMERATE
-    | win32con.DESKTOP_HOOKCONTROL
-    | win32con.DESKTOP_JOURNALPLAYBACK
-    | win32con.DESKTOP_JOURNALRECORD
-    | win32con.DESKTOP_READOBJECTS
-    | win32con.DESKTOP_SWITCHDESKTOP
-    | win32con.DESKTOP_WRITEOBJECTS
-    | win32con.DELETE
-    | win32con.READ_CONTROL
-    | win32con.WRITE_DAC
-    | win32con.WRITE_OWNER
-)
-
-
 class PopenAsUser(Popen):
     """Popen implementation that launches new process using the windows auth token provided.
 

--- a/winlocalprocessspawner/win_utils.py
+++ b/winlocalprocessspawner/win_utils.py
@@ -307,4 +307,4 @@ class PopenAsUser(Popen):
             self._handle = Handle(hp.Detach())
             self.pid = pid
         finally:
-            CLOSEHANDLE(ht)
+            win32api.CloseHandle(ht)

--- a/winlocalprocessspawner/win_utils.py
+++ b/winlocalprocessspawner/win_utils.py
@@ -1,6 +1,5 @@
 """Windows process-launching helpers for running JupyterHub single-user servers as another user."""
 
-import ctypes
 import logging
 import os
 import sys

--- a/winlocalprocessspawner/winlocalprocessspawner.py
+++ b/winlocalprocessspawner/winlocalprocessspawner.py
@@ -36,6 +36,24 @@ class WinLocalProcessSpawner(LocalProcessSpawner):
                 env[key] = os.environ[key]
         return env
 
+    def _apply_user_env_overrides(self, env, user_env, token):
+        """Apply user environment from CreateEnvironmentBlock to the process env.
+
+        Called after CreateEnvironmentBlock returns. Subclasses can override
+        to customize the environment after the block has been merged.
+
+        :param env: The process environment dict built by get_env().
+        :param user_env: The environment dict from CreateEnvironmentBlock, or None on failure.
+        :param token: The Windows auth token, or None.
+        """
+        if token and user_env:
+            env.update(user_env)
+        if user_env and 'APPDATA' not in user_env:
+            # If APPDATA does not exist, the USERPROFILE points at the default
+            # directory which is not writable. Change the path to public
+            # documents, so at least it's a writable location.
+            env['USERPROFILE'] = user_env.get('PUBLIC', env.get('PUBLIC', ''))
+
     async def start(self):
         """Start the single-user server."""
         self.port = random_port()
@@ -68,22 +86,15 @@ class WinLocalProcessSpawner(LocalProcessSpawner):
             user_env = win32profile.CreateEnvironmentBlock(token, False)
         except Exception as exc:
             self.log.warning("Failed to load user environment for %s: %s", self.user.name, exc)
-        else:
-            # Only load user environment if we hold a valid auth token
-            if token:
-                env.update(user_env)
-            if "APPDATA" not in user_env:
-                # If the 'APPDATA' does not exist, the USERPROFILE points at the default
-                # directory which is not writable. this changes the path over to public
-                # documents, so at least its a writable location.
-                user_env["USERPROFILE"] = user_env["PUBLIC"]
+
+        self._apply_user_env_overrides(env, user_env, token)
 
         # On Posix, the cwd is set to ~ before spawning the singleuser server (preexec_fn).
         # Windows Popen doesn't have preexec_fn support, so we need to set cwd directly.
         if self.notebook_dir:
             cwd = os.getcwd()
-        elif env["APPDATA"]:
-            cwd = user_env["USERPROFILE"]
+        elif env.get('APPDATA'):
+            cwd = env.get('USERPROFILE', mkdtemp())
         else:
             # Set CWD to a temp directory, since we failed to load the user profile
             cwd = mkdtemp()

--- a/winlocalprocessspawner/winlocalprocessspawner.py
+++ b/winlocalprocessspawner/winlocalprocessspawner.py
@@ -44,7 +44,8 @@ class WinLocalProcessSpawner(LocalProcessSpawner):
         by the profile block (e.g. custom APPDATA in least-privilege mode).
 
         :param env: The spawner-built environment dict from get_env(). Modified in place.
-        :param profile_env: The Windows user profile env from CreateEnvironmentBlock, or None on failure.
+        :param profile_env: The Windows user profile env from CreateEnvironmentBlock, or None on
+            failure.
         :param token: The Windows auth token, or None.
         """
         if token and profile_env:

--- a/winlocalprocessspawner/winlocalprocessspawner.py
+++ b/winlocalprocessspawner/winlocalprocessspawner.py
@@ -36,23 +36,29 @@ class WinLocalProcessSpawner(LocalProcessSpawner):
                 env[key] = os.environ[key]
         return env
 
-    def _apply_user_env_overrides(self, env, user_env, token):
-        """Apply user environment from CreateEnvironmentBlock to the process env.
+    def _apply_user_env_overrides(self, env, profile_env, token):
+        """Merge the Windows user profile environment into the spawner-built env.
 
         Called after CreateEnvironmentBlock returns. Subclasses can override
-        to customize the environment after the block has been merged.
+        this method to protect specific keys in `env` from being overwritten
+        by the profile block (e.g. custom APPDATA in least-privilege mode).
 
-        :param env: The process environment dict built by get_env().
-        :param user_env: The environment dict from CreateEnvironmentBlock, or None on failure.
+        :param env: The spawner-built environment dict from get_env(). Modified in place.
+        :param profile_env: The Windows user profile env from CreateEnvironmentBlock, or None on failure.
         :param token: The Windows auth token, or None.
         """
-        if token and user_env:
-            env.update(user_env)
-        if user_env and 'APPDATA' not in user_env:
-            # If APPDATA does not exist, the USERPROFILE points at the default
-            # directory which is not writable. Change the path to public
-            # documents, so at least it's a writable location.
-            env['USERPROFILE'] = user_env.get('PUBLIC', env.get('PUBLIC', ''))
+        if token and profile_env:
+            # Merge the Windows profile block into the spawner env.
+            # Note: profile_env values overwrite any matching keys already in env.
+            # Subclasses that need to protect specific keys (e.g. APPDATA set to a
+            # custom profile directory) should snapshot those keys before calling
+            # super() and restore them after.
+            env.update(profile_env)
+        if profile_env and 'APPDATA' not in profile_env:
+            # The profile loaded but has no APPDATA — the user profile directory is
+            # not fully set up, so USERPROFILE would point at a non-writable default.
+            # Fall back to the PUBLIC directory, which is always writable.
+            env['USERPROFILE'] = profile_env.get('PUBLIC', env.get('PUBLIC', ''))
 
     async def start(self):
         """Start the single-user server."""
@@ -78,16 +84,16 @@ class WinLocalProcessSpawner(LocalProcessSpawner):
             if token:
                 token = pywintypes.HANDLE(token)
 
-        user_env = None
+        profile_env = None
         cwd = None
 
         try:
-            # Will load user variables, if the user profile is loaded
-            user_env = win32profile.CreateEnvironmentBlock(token, False)
+            # Load the Windows user profile environment for the authenticated token.
+            profile_env = win32profile.CreateEnvironmentBlock(token, False)
         except Exception as exc:
             self.log.warning("Failed to load user environment for %s: %s", self.user.name, exc)
 
-        self._apply_user_env_overrides(env, user_env, token)
+        self._apply_user_env_overrides(env, profile_env, token)
 
         # On Posix, the cwd is set to ~ before spawning the singleuser server (preexec_fn).
         # Windows Popen doesn't have preexec_fn support, so we need to set cwd directly.

--- a/winlocalprocessspawner/winlocalprocessspawner.py
+++ b/winlocalprocessspawner/winlocalprocessspawner.py
@@ -100,7 +100,12 @@ class WinLocalProcessSpawner(LocalProcessSpawner):
         if self.notebook_dir:
             cwd = os.getcwd()
         elif env.get("APPDATA"):
-            cwd = env.get("USERPROFILE", mkdtemp())
+            if token:
+                # Merge happened — USERPROFILE in env reflects any subclass overrides.
+                cwd = env.get("USERPROFILE", mkdtemp())
+            else:
+                # Merge was skipped — read USERPROFILE directly from the profile block.
+                cwd = profile_env.get("USERPROFILE", mkdtemp()) if profile_env else mkdtemp()
         else:
             # Set CWD to a temp directory, since we failed to load the user profile
             cwd = mkdtemp()

--- a/winlocalprocessspawner/winlocalprocessspawner.py
+++ b/winlocalprocessspawner/winlocalprocessspawner.py
@@ -54,11 +54,11 @@ class WinLocalProcessSpawner(LocalProcessSpawner):
             # custom profile directory) should snapshot those keys before calling
             # super() and restore them after.
             env.update(profile_env)
-        if profile_env and 'APPDATA' not in profile_env:
+        if profile_env and "APPDATA" not in profile_env:
             # The profile loaded but has no APPDATA — the user profile directory is
             # not fully set up, so USERPROFILE would point at a non-writable default.
             # Fall back to the PUBLIC directory, which is always writable.
-            env['USERPROFILE'] = profile_env.get('PUBLIC', env.get('PUBLIC', ''))
+            env["USERPROFILE"] = profile_env.get("PUBLIC", env.get("PUBLIC", ""))
 
     async def start(self):
         """Start the single-user server."""
@@ -99,8 +99,8 @@ class WinLocalProcessSpawner(LocalProcessSpawner):
         # Windows Popen doesn't have preexec_fn support, so we need to set cwd directly.
         if self.notebook_dir:
             cwd = os.getcwd()
-        elif env.get('APPDATA'):
-            cwd = env.get('USERPROFILE', mkdtemp())
+        elif env.get("APPDATA"):
+            cwd = env.get("USERPROFILE", mkdtemp())
         else:
             # Set CWD to a temp directory, since we failed to load the user profile
             cwd = mkdtemp()


### PR DESCRIPTION
- Add `_apply_user_env_overrides` hook to WinLocalProcessSpawner to isolate the logic that merges `CreateEnvironmentBlock` results into the process environment, making it easier for subclasses to customize.
- Add unit tests covering all branches of `_apply_user_env_overrides`.
- Replace `CLOSEHANDLE(ht)` with `win32api.CloseHandle(ht)` in win_utils.py to fix a `DeprecationWarning` caused by implicit `PyHANDLE` → `int` conversion removed in newer Python versions.
- Fix `token_utils.py` type annotation to use `pywintypes.HANDLEType` for the return type of `restrict_token`